### PR TITLE
[Feat] 게임 타이머 개선 #3

### DIFF
--- a/run.py
+++ b/run.py
@@ -134,6 +134,10 @@ class InputController:
             game.board.reveal(col, row)
     
         elif button == config.mouse_right:
+            if not game.started:
+                game.started = True 
+                game.start_ticks_ms = pygame.time.get_ticks()
+                
             game.board.toggle_flag(col, row)
            
         elif button == config.mouse_middle:

--- a/run.py
+++ b/run.py
@@ -125,19 +125,16 @@ class InputController:
 
         cell_state = game.board.cells[game.board.index(col, row)].state
 
+        if (button == config.mouse_left or button == config.mouse_right) and not game.started:
+            game.started = True
+            game.start_ticks_ms = pygame.time.get_ticks()
+
         if button == config.mouse_left:
             print("Left button to open a cell")
-            if not game.started:
-                game.started = True 
-                game.start_ticks_ms = pygame.time.get_ticks()
-        
             game.board.reveal(col, row)
     
         elif button == config.mouse_right:
-            if not game.started:
-                game.started = True 
-                game.start_ticks_ms = pygame.time.get_ticks()
-                
+
             game.board.toggle_flag(col, row)
            
         elif button == config.mouse_middle:


### PR DESCRIPTION
공통 입력/타이머 시작 로직(start_ticks_ms 설정)을 담당합니다. 다른 PR들(#9 , #10 , #11 )이 이를 전제로 합니다.
다른 PR들(#9 , #10 , #11 )보다 먼저 병합하는 것을 권장합니다.

게임 타이머가 이미 구현되어있어, 추가 기능이 아닌 기능 개선을 진행하였습니다.
기존에는 좌클릭으로 셀을 열었을 때만 타이머가 시작되었으나, 우클릭으로 깃발을 설치하였을 때도 타이머가 시작되도록 개선했습니다.
가운데 클릭은 타이머 시작 조건에 포함하지 않았습니다.