### PR TITLE
[Feat] 재시작 버튼 구현 #4

### DIFF
--- a/run.py
+++ b/run.py
@@ -127,7 +127,8 @@ class InputController:
 
     def handle_mouse(self, pos, button) -> None:
         # Restart button click (left click)
-        if button == config.mouse_left and self.game.restart_rect.collidepoint(pos):
+        restart_rect = getattr(self.game, "restart_rect", None)
+        if button == config.mouse_left and restart_rect and restart_rect.collidepoint(pos):
             self.game.reset()
             return
         col, row = self.pos_to_grid(pos[0], pos[1])
@@ -141,9 +142,6 @@ class InputController:
 
         if button == config.mouse_left:
             print("Left button to open a cell")
-            if not game.started:
-                game.started = True 
-                game.start_ticks_ms = pygame.time.get_ticks()
         
             game.board.reveal(col, row)
     

--- a/run.py
+++ b/run.py
@@ -31,6 +31,7 @@ class Renderer:
         self.font = pygame.font.Font(config.font_name, config.font_size)
         self.header_font = pygame.font.Font(config.font_name, config.header_font_size)
         self.result_font = pygame.font.Font(config.font_name, config.result_font_size)
+        self.restart_rect: Rect | None = None
 
     def cell_rect(self, col: int, row: int) -> Rect:
         """Return the rectangle in pixels for the given grid cell."""
@@ -71,7 +72,7 @@ class Renderer:
                 )
         pygame.draw.rect(self.screen, config.color_grid, rect, 1)
 
-    def draw_header(self, remaining_mines: int, time_text: str, restart_rect: Rect) -> None:
+    def draw_header(self, remaining_mines: int, time_text: str) -> None:
         """Draw the header bar containing remaining mines and elapsed time."""
         pygame.draw.rect(
             self.screen,
@@ -85,8 +86,10 @@ class Renderer:
         self.screen.blit(left_label, (10, 12))
         self.screen.blit(right_label, (config.width - right_label.get_width() - 10, 12))
 
-        pygame.draw.rect(self.screen, config.color_cell_hidden, restart_rect)
-        pygame.draw.rect(self.screen, config.color_grid, restart_rect, 2)
+        restart_rect = self.restart_rect
+        if restart_rect is not None:
+            pygame.draw.rect(self.screen, config.color_cell_hidden, restart_rect)
+            pygame.draw.rect(self.screen, config.color_grid, restart_rect, 2)
 
         btn_label = self.header_font.render("Restart", True, config.color_header_text)
         btn_rect = btn_label.get_rect(center=restart_rect.center)
@@ -202,6 +205,7 @@ class Game:
         self.start_ticks_ms = 0
         self.end_ticks_ms = 0
         self.restart_rect = Rect(config.width // 2 - 60, 10, 120, 36)
+        self.renderer.restart_rect = self.restart_rect
 
     def reset(self):
         """Reset the game state and start a new board."""
@@ -243,7 +247,7 @@ class Game:
         self.screen.fill(config.color_bg)
         remaining = max(0, config.num_mines - self.board.flagged_count())
         time_text = self._format_time(self._elapsed_ms())
-        self.renderer.draw_header(remaining, time_text, self.restart_rect)
+        self.renderer.draw_header(remaining, time_text)
         now = pygame.time.get_ticks()
         for r in range(self.board.rows):
             for c in range(self.board.cols):

--- a/run.py
+++ b/run.py
@@ -71,7 +71,7 @@ class Renderer:
                 )
         pygame.draw.rect(self.screen, config.color_grid, rect, 1)
 
-    def draw_header(self, remaining_mines: int, time_text: str) -> None:
+    def draw_header(self, remaining_mines: int, time_text: str, restart_rect: Rect) -> None:
         """Draw the header bar containing remaining mines and elapsed time."""
         pygame.draw.rect(
             self.screen,
@@ -84,6 +84,13 @@ class Renderer:
         right_label = self.header_font.render(right_text, True, config.color_header_text)
         self.screen.blit(left_label, (10, 12))
         self.screen.blit(right_label, (config.width - right_label.get_width() - 10, 12))
+
+        pygame.draw.rect(self.screen, config.color_cell_hidden, restart_rect)
+        pygame.draw.rect(self.screen, config.color_grid, restart_rect, 2)
+
+        btn_label = self.header_font.render("Restart", True, config.color_header_text)
+        btn_rect = btn_label.get_rect(center=restart_rect.center)
+        self.screen.blit(btn_label, btn_rect)
 
     def draw_result_overlay(self, text: str | None) -> None:
         """Draw a semi-transparent overlay with centered result text, if any."""
@@ -116,6 +123,10 @@ class InputController:
         return -1, -1
 
     def handle_mouse(self, pos, button) -> None:
+        # Restart button click (left click)
+        if button == config.mouse_left and self.game.restart_rect.collidepoint(pos):
+            self.game.reset()
+            return
         col, row = self.pos_to_grid(pos[0], pos[1])
         if col == -1:
             return
@@ -190,6 +201,7 @@ class Game:
         self.started = False
         self.start_ticks_ms = 0
         self.end_ticks_ms = 0
+        self.restart_rect = Rect(config.width // 2 - 60, 10, 120, 36)
 
     def reset(self):
         """Reset the game state and start a new board."""
@@ -231,7 +243,7 @@ class Game:
         self.screen.fill(config.color_bg)
         remaining = max(0, config.num_mines - self.board.flagged_count())
         time_text = self._format_time(self._elapsed_ms())
-        self.renderer.draw_header(remaining, time_text)
+        self.renderer.draw_header(remaining, time_text, self.restart_rect)
         now = pygame.time.get_ticks()
         for r in range(self.board.rows):
             for c in range(self.board.cols):

--- a/run.py
+++ b/run.py
@@ -91,9 +91,9 @@ class Renderer:
             pygame.draw.rect(self.screen, config.color_cell_hidden, restart_rect)
             pygame.draw.rect(self.screen, config.color_grid, restart_rect, 2)
 
-        btn_label = self.header_font.render("Restart", True, config.color_header_text)
-        btn_rect = btn_label.get_rect(center=restart_rect.center)
-        self.screen.blit(btn_label, btn_rect)
+            btn_label = self.header_font.render("Restart", True, config.color_header_text)
+            btn_rect = btn_label.get_rect(center=restart_rect.center)
+            self.screen.blit(btn_label, btn_rect)
 
     def draw_result_overlay(self, text: str | None) -> None:
         """Draw a semi-transparent overlay with centered result text, if any."""


### PR DESCRIPTION
이 PR은 헤더UI 기능만 포함합니다. 타이머 시작 로직은 PR #8 에 포함되어 있으니 #8 을 먼저 머지해 주세요.
병합은 이슈 번호 순서대로 진행하는 것을 권장합니다.

게임 헤더에 새 게임을 시작할 수 있도록 재시작 버튼을 추가했습니다.
재시작 시 보드 상태, 타이머, 깃발 상태가 모두 초기화됩니다.