### PR TITLE
[Feat] 깃발 카운터 기능 구현 #5

### DIFF
--- a/run.py
+++ b/run.py
@@ -78,6 +78,7 @@ class Renderer:
             config.color_header,
             Rect(0, 0, config.width, config.margin_top - 4),
         )
+        flags = self.board.flagged_count()
         left_text = f"Mines: {remaining_mines} | Flags: {flags}"
         right_text = f"Time: {time_text}"
         left_label = self.header_font.render(left_text, True, config.color_header_text)

--- a/run.py
+++ b/run.py
@@ -71,14 +71,14 @@ class Renderer:
                 )
         pygame.draw.rect(self.screen, config.color_grid, rect, 1)
 
-    def draw_header(self, remaining_mines: int, time_text: str) -> None:
+    def draw_header(self, remaining_mines: int, time_text: str, flags: int) -> None:
         """Draw the header bar containing remaining mines and elapsed time."""
         pygame.draw.rect(
             self.screen,
             config.color_header,
             Rect(0, 0, config.width, config.margin_top - 4),
         )
-        left_text = f"Mines: {remaining_mines}"
+        left_text = f"Mines: {remaining_mines} | Flags: {flags}"
         right_text = f"Time: {time_text}"
         left_label = self.header_font.render(left_text, True, config.color_header_text)
         right_label = self.header_font.render(right_text, True, config.color_header_text)
@@ -229,9 +229,10 @@ class Game:
         if pygame.time.get_ticks() > self.highlight_until_ms and self.highlight_targets:
             self.highlight_targets.clear()
         self.screen.fill(config.color_bg)
-        remaining = max(0, config.num_mines - self.board.flagged_count())
+        flags = self.board.flagged_count()
+        remaining = max(0, config.num_mines - flags)
         time_text = self._format_time(self._elapsed_ms())
-        self.renderer.draw_header(remaining, time_text)
+        self.renderer.draw_header(remaining, time_text, flags)
         now = pygame.time.get_ticks()
         for r in range(self.board.rows):
             for c in range(self.board.cols):

--- a/run.py
+++ b/run.py
@@ -128,9 +128,6 @@ class InputController:
 
         if button == config.mouse_left:
             print("Left button to open a cell")
-            if not game.started:
-                game.started = True 
-                game.start_ticks_ms = pygame.time.get_ticks()
         
             game.board.reveal(col, row)
     

--- a/run.py
+++ b/run.py
@@ -71,7 +71,7 @@ class Renderer:
                 )
         pygame.draw.rect(self.screen, config.color_grid, rect, 1)
 
-    def draw_header(self, remaining_mines: int, time_text: str, flags: int) -> None:
+    def draw_header(self, remaining_mines: int, time_text: str) -> None:
         """Draw the header bar containing remaining mines and elapsed time."""
         pygame.draw.rect(
             self.screen,
@@ -230,10 +230,9 @@ class Game:
         if pygame.time.get_ticks() > self.highlight_until_ms and self.highlight_targets:
             self.highlight_targets.clear()
         self.screen.fill(config.color_bg)
-        flags = self.board.flagged_count()
-        remaining = max(0, config.num_mines - flags)
+        remaining = max(0, config.num_mines - self.board.flagged_count())
         time_text = self._format_time(self._elapsed_ms())
-        self.renderer.draw_header(remaining, time_text, flags)
+        self.renderer.draw_header(remaining, time_text)
         now = pygame.time.get_ticks()
         for r in range(self.board.rows):
             for c in range(self.board.cols):


### PR DESCRIPTION
이 PR은 헤더UI 기능만 포함합니다. 타이머 시작 로직은 PR #8 에 포함되어 있으니 #8 을 먼저 머지해 주세요.
병합은 이슈 번호 순서대로 진행하는 것을 권장합니다.

헤더에 현재 설치된 깃발 개수를 표시하도록 했습니다.
깃발 설치 및 해제 시 값이 실시간으로 갱신됩니다.